### PR TITLE
Fixing issue where most streams wouldn't work.

### DIFF
--- a/Contents/Services/URL/USTVnow/ServiceCode.pys
+++ b/Contents/Services/URL/USTVnow/ServiceCode.pys
@@ -24,24 +24,4 @@ def MediaObjectsForURL(url):
 ####################################################################################################
 @indirect
 def PlayVideo(url):
-    streams = []
-    playList = HTTP.Request(url).content
-    for line in playList.splitlines():
-        if 'BANDWIDTH' in line:
-            stream = {}
-            stream['bitrate'] = int(Regex('(?<=BANDWIDTH=)[0-9]+').search(line).group(0))
-
-            if 'RESOLUTION' in line:
-                stream['resolution'] = int(Regex('(?<=RESOLUTION=)[0-9]+x[0-9]+').search(line).group(0).split('x')[1])
-            else:
-                stream['resolution'] = 0
-
-        elif '.m3u8' in line:
-            if not line.startswith('http://'):
-                path = url[:url.rfind('/') + 1]
-                stream['url'] = path + line
-
-            streams.append(stream)
-
-    sorted_streams = sorted(streams, key = lambda stream: stream['bitrate'], reverse = True)
-    return IndirectResponse(VideoClipObject, key=HTTPLiveStreamURL(url=sorted_streams[0]['url']))
+    return IndirectResponse(VideoClipObject, key=HTTPLiveStreamURL(url=url))

--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
-USTVnow.bundle
-==============
+# USTVnow Plex Plug-in
 
-I am no longer supporting this plugin.
+## Getting Started
+
+1.  [Download the zip file](https://github.com/lukebussey/USTVnow.bundle/archive/master.zip).
+2.  Unzip and rename to `USTVnow.bundle`.
+3.  Copy to your Plex Plugin folder:
+
+    **MacOS:** `~/Library/Application Support/Plex Media Server/Plug-ins`<br>
+    **Windows:** `%LOCALAPPDATA%\Plex Media Server\Plug-ins\`<br>
+    **Linux:** `$PLEX_HOME/Library/Application Support/Plex Media Server/Plug-ins`
+
+## Change Log
+
+**2016-09-24:** Fixing Issue where most channels wouldn’t work due to using Akamai streams.<br>
+**2016-09-24:** Forking repo from [jwdempsey/USTVnow.bundle](https://github.com/jwdempsey/USTVnow.bundle).


### PR DESCRIPTION
I've fixed the issue where most streams wouldn't work due to USTVnow changing their streams to use Akamai.

Would you be able to merge this in, or alternatively assign an open source license such as MIT so that I can legally fork and maintain the plugin?